### PR TITLE
wrapped up parsing of postprocessed OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+kubeconfig

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.17 AS build
 WORKDIR /go/src
 COPY . .
-
-
+COPY ./kubeconfig .
 ENV CGO_ENABLED=0
 RUN go get -d -v ./...
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/kubeshop/kusk-gateway v0.0.0-alpha.2.1.4.0.20220316121026-aef038baad91
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
 	k8s.io/client-go v0.23.4
@@ -53,8 +55,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/server/go/api_apis_service_impl.go
+++ b/server/go/api_apis_service_impl.go
@@ -14,9 +14,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/GIT_USER_ID/GIT_REPO_ID/util"
 	"github.com/kubeshop/kusk-gateway/api/v1alpha1"
 	kuskv1 "github.com/kubeshop/kusk-gateway/api/v1alpha1"
 	"github.com/kubeshop/kusk-gateway/pkg/spec"
+	"gopkg.in/yaml.v2"
 )
 
 // GetApis - Get a list of APIs
@@ -65,20 +67,10 @@ func (s *ApisApiService) GetPostProcessedOpenApiSpec(ctx context.Context, namesp
 	if err != nil {
 		return Response(http.StatusInternalServerError, err), err
 	}
-	parser := spec.NewParser(nil)
+	rawyaml := util.ParseKuskOpenAPI(api.Spec.Spec)
+	yml, _ := yaml.Marshal(rawyaml)
 
-	apiSpec, err := parser.ParseFromReader(strings.NewReader(api.Spec.Spec))
-
-	if err != nil {
-		return Response(http.StatusInternalServerError, nil), err
-	}
-
-	opts, err := spec.GetOptions(apiSpec)
-	if err != nil {
-		return Response(http.StatusInternalServerError, nil), err
-	}
-
-	return Response(http.StatusOK, opts), nil
+	return Response(http.StatusOK, string(yml)), nil
 }
 
 func (s *ApisApiService) convertAPIListCRDtoAPIsModel(apis v1alpha1.APIList) []ApiItem {

--- a/server/util/util.go
+++ b/server/util/util.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ParseKuskOpenAPI(yyml string) map[string]interface{} {
+	var yml map[string]interface{}
+	err := yaml.Unmarshal([]byte(yyml), &yml)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fresh_yml := make(map[string]interface{})
+	for k, v := range yml {
+		switch v.(type) {
+		case string:
+			fresh_yml[k] = v
+		case map[string]interface{}:
+			if k != "x-kusk" {
+				fresh_yml[k] = parseNode(k, v.(map[string]interface{}))
+			}
+		}
+
+	}
+	return fresh_yml
+}
+
+func parseNode(parent interface{}, v map[string]interface{}) map[string]interface{} {
+	yml := make(map[string]interface{})
+
+	for kk, vv := range v {
+		switch vv.(type) {
+		case string:
+			if kk != "x-kusk" {
+				yml[kk] = vv
+			}
+		case map[string]interface{}:
+			if kk == "x-kusk" {
+				ksk := getXKusk(vv)
+				parentksk := getXKusk(parent)
+				if parentksk != nil && ksk != nil {
+					if parentksk.Disabled && !ksk.Disabled {
+						yml[kk] = parseNode(vv, vv.(map[string]interface{}))
+					}
+				}
+			}
+
+			if kk != "x-kusk" {
+				yml[kk] = parseNode(vv, vv.(map[string]interface{}))
+			}
+		case []interface{}:
+			yml[kk] = vv
+		default:
+			break
+		}
+	}
+	return yml
+}
+
+func getXKusk(value interface{}) *XKusk {
+	jsn, _ := json.Marshal(value)
+	xkusk := &XKusk{}
+
+	if err := json.Unmarshal(jsn, xkusk); err != nil {
+		fmt.Println(err)
+	}
+	return xkusk
+}
+
+type XKusk struct {
+	Disabled bool `json:"disabled,omitempty"`
+}


### PR DESCRIPTION
Signed-off-by: Jasmin Gacic <jasmin.gacic@gmail.com>

the endpoint will produce the output below out of https://github.com/kubeshop/kusk-gateway/blob/main/examples/httpbin/httpbin_v1_api.yaml

```
host: httpbin.org
info:
  description: API Management facade for a very handy and free online HTTP tool.
  title: httpbin.org
  version: "1.0"
paths:
  /anything:
    get:
      description: Returns request data, including method used.
      operationId: /anything
      responses: {}
  /base64/{value}:
    get:
      description: Decodes base64url-encoded string.
      operationId: /base64
      parameters:
      - default: aGVsbG8gd29ybGQNCg%3D%3D
        description: Base64 encoded string.
        in: path
        name: value
        required: true
        type: string
      responses: {}
  /brotli:
    get:
      description: Returns brotli-encoded data.
      operationId: /brotli
      responses: {}
  /bytes/{number}:
    get:
      description: Generates n random bytes of binary data
      operationId: /bytes
      parameters:
      - default: "1024"
        description: Number of bytes to return.
        in: path
        name: number
        required: true
        type: string
      responses: {}
  /cache/{maxAge}:
    get:
      description: Sets a Cache-Control header for n seconds.
      operationId: /cache
      parameters:
      - default: 10
        description: ""
        in: path
        name: maxAge
        required: true
        type: string
      responses: {}
  /deflate:
    get:
      description: Returns deflate-encoded data.
      operationId: /deflate
      responses: {}
  /delay/{seconds}:
    get:
      description: Delays responding for n–10 seconds.
      operationId: /delay
      parameters:
      - default: 2
        description: ""
        enum:
        - 2
        in: path
        name: seconds
        required: true
        type: string
      responses: {}
  /delete:
    delete:
      description: Returns DELETE data.
      operationId: /delete
      responses: {}
  /get:
    get:
      description: Returns GET data.
      operationId: /get
      responses: {}
  /gzip:
    get:
      description: Returns gzip-encoded data.
      operationId: /gzip
      responses: {}
  /headers:
    get:
      description: Returns headers dictionary.
      operationId: /headers
      responses: {}
  /ip:
    get:
      description: Returns origin IP.
      operationId: /ip
      responses: {}
  /oldAPI/stream/{number}:
    get:
      description: Old stream, rewrite to new.
      parameters:
      - default: "10"
        description: Number of lines to stream.
        in: path
        name: number
        required: true
        type: number
      responses: {}
  /oldAPI/streamOld/{number}:
    get:
      description: Old stream, redirect to new.
      parameters:
      - default: "10"
        description: Number of lines to stream.
        in: path
        name: number
        required: true
        type: number
      responses: {}
  /patch:
    patch:
      description: Returns PATCH data.
      operationId: /patch
      responses: {}
  /post:
    post:
      description: Returns POST data.
      operationId: /post
      responses: {}
  /put:
    put:
      description: Returns PUT data.
      operationId: /put
      responses: {}
  /redirect-to:
    get:
      description: 302 redirects to a URL provided in query
      operationId: /redirect-to
      parameters:
      - default: http://example.com
        description: Redirect target
        in: query
        name: url
        required: true
        type: string
      responses: {}
  /response-headers:
    get:
      description: Returns key-value query parameters as response headers.
      operationId: /response-headers
      responses: {}
  /status/{code}:
    get:
      description: Returns provided HTTP Status code.
      operationId: /status
      parameters:
      - default: 200
        description: HTTP code to return.
        enum:
        - 200
        - 201
        - 202
        - 203
        - 204
        - 205
        - 206
        - 207
        - 208
        - 226
        - 300
        - 301
        - 302
        - 303
        - 304
        - 305
        - 306
        - 307
        - 308
        - 400
        - 401
        - 403
        - 404
        - 500
        - 501
        - 502
        - 503
        - 504
        in: path
        name: code
        required: true
        type: number
      responses: {}
  /stream/{number}:
    get:
      description: Streams min(number, 100) lines.
      operationId: /stream
      parameters:
      - default: "10"
        description: Number of lines to stream.
        in: path
        name: number
        required: true
        type: number
      responses: {}
  /user-agent:
    get:
      description: Returns user agent string.
      operationId: /user-agent
      responses: {}
  /uuid:
    get:
      description: Returns UUID4.
      operationId: /uuid
      responses: {}
  /xml:
    get:
      description: Returns some XML.
      operationId: /xml
      responses: {}
swagger: "2.0"
```