### PR TITLE
feat: add fleet staticRoutes + crd query param

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -230,6 +230,12 @@ paths:
           schema:
             type: string
           description: the name of the fleet
+        - name: crd
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: returns the fleet CRD
       responses:
         200:
           description: envoy fleet details
@@ -294,7 +300,21 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ServiceItem"
+        staticRoutes:
+          type: array
+          items:
+            $ref: "#/components/schemas/StaticRouteItem_Fleet"
     ApiItem_Fleet:
+      type: object
+      required:
+        - name
+        - namespace
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+    StaticRouteItem_Fleet:
       type: object
       required:
         - name


### PR DESCRIPTION
## Changes

- Add `staticRoutes` for fleet item
- boolean crd query param for `/fleets/{namespace}/{name}` that will return the fleet CRD yaml
