### PR TITLE
Set up build and run automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build
+
+concurrency:
+  group: build
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
+build:
+	docker build -t kusk-gateway-api server
+
 server-generate:
 	openapi-generator-cli generate -i api/openapi.yaml -g go-server -o server/ --additional-properties=featureCORS=true
+
 run:
-	docker-compose up --build -d 
+	docker-compose up --build -d
+
+run-minikube:
+	docker-compose -f docker-compose.yaml -f docker-compose-minikube.yaml up --build -d

--- a/docker-compose-minikube.yaml
+++ b/docker-compose-minikube.yaml
@@ -1,0 +1,5 @@
+version: "3"
+services:
+  kgwapi:
+    volumes:
+      - $HOME/.minikube:$HOME/.minikube:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,5 +2,9 @@ version: "3"
 services:
   kgwapi:
     build: ./server
+    environment:
+      - KUBECONFIG=/kube/config
+    volumes:
+      - $HOME/.kube/config:/kube/config:ro
     ports:
       - 8080:8080

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,15 +1,18 @@
 FROM golang:1.17 AS build
 WORKDIR /go/src
-COPY . .
-COPY ./kubeconfig .
-ENV CGO_ENABLED=0
-RUN go get -d -v ./...
+# Copy `go.mod` for definitions and `go.sum` to invalidate the next layer
+# in case of a change in the dependencies
+COPY go.mod go.sum ./
+# Download dependencies
+RUN go mod download
 
-RUN go build -a -installsuffix cgo -o kusk-gateway-api .
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o kusk-gateway-api
 
 FROM scratch AS runtime
-COPY --from=build /go/src/kusk-gateway-api ./
-COPY --from=build /go/src/kubeconfig ./
-ENV KUBECONFIG=kubeconfig
+COPY --from=build --chown=65532:65532 /go/src/kusk-gateway-api ./
 EXPOSE 8080/tcp
+
+USER 65532:65532
+
 ENTRYPOINT ["./kusk-gateway-api"]

--- a/server/README.md
+++ b/server/README.md
@@ -25,10 +25,20 @@ go run main.go
 
 To run the server in a docker container
 ```
-docker build --network=host -t openapi .
+make build
 ```
 
 Once image is built use
 ```
-docker run --rm -it openapi
+make run
+```
+
+To run in Minikube
+```
+make run-minikube
+```
+
+To stop the api
+```
+docker-compose down
 ```


### PR DESCRIPTION
adds github build action and updates docker-compose set up to allow for not baking the kubeconfig into the image
## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
