### PR TITLE
Add probe controller for health checks

### DIFF
--- a/server/go/probe.go
+++ b/server/go/probe.go
@@ -1,0 +1,24 @@
+package openapi
+
+import "net/http"
+
+type ProbeController struct{}
+
+func NewProbeControler() Router {
+	return &ProbeController{}
+}
+
+func (c *ProbeController) Routes() Routes {
+	return Routes{
+		{
+			"Health",
+			http.MethodGet,
+			"/",
+			c.Healthz,
+		},
+	}
+}
+
+func (c *ProbeController) Healthz(w http.ResponseWriter, r *http.Request) {
+	EncodeJSONResponse("200 OK", nil, w)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -46,7 +46,14 @@ func main() {
 	ServicesApiService := openapi.NewServicesApiService(kuskClient)
 	ServicesApiController := openapi.NewServicesApiController(ServicesApiService)
 
-	router := openapi.NewRouter(ApisApiController, FleetsApiController, ServicesApiController)
+	ProbeController := openapi.NewProbeControler()
+
+	router := openapi.NewRouter(
+		ApisApiController,
+		FleetsApiController,
+		ServicesApiController,
+		ProbeController,
+	)
 
 	log.Fatal(http.ListenAndServe(":8080", router))
 }


### PR DESCRIPTION
This PR adds a healthz endpoint for kubernetes liveness and readiness probes

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
