### PR TITLE
fix: delete api endpoint definition 

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -292,6 +292,28 @@ paths:
                 $ref: "#/components/schemas/EnvoyFleetItem"
         404:
           description: "Envoy fleet not found by namespace-name combination"
+    delete:
+      tags:
+        - "fleets"
+      summary: "Delete a Fleet instance by namespace and name"
+      operationId: deleteFleet
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+            default: "default"
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: "fleet item deleted"
+        404:
+          description: "fleet item not found"
   /fleets/{namespace}/{name}/crd:
     get:
       tags:
@@ -409,6 +431,28 @@ paths:
                 $ref: "#/components/schemas/StaticRouteItem"
         404:
           description: "Static Route not found by namespace-name combination"
+    delete:
+      tags:
+        - "static Route"
+      summary: "Delete a StaticRoute by namespace and name"
+      operationId: deleteStaticRoute
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+            default: "default"
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: "staticRoute item deleted"
+        404:
+          description: "staticRoute item not found"
   /staticroutes/{namespace}/{name}/crd:
     get:
       tags:
@@ -584,4 +628,3 @@ components:
       properties:
         name:
           type: string
-

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -114,6 +114,28 @@ paths:
                 $ref: "#/components/schemas/ApiItem"
         404:
           description: "API item not found"
+    delete:
+      tags:
+        - "apis"
+      summary: "Delete an API instance by namespace and name"
+      operationId: deleteApi
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+            default: "default"
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: "api item deleted"
+        404:
+          description: "api item not found"
   /apis/{namespace}/{name}/crd:
     get:
       tags:


### PR DESCRIPTION
This PR...

## Changes
- give Kuskgateway ability to delete (api- fleet- static route) from the dashboard 
- related issue https://github.com/kubeshop/kusk-gateway/issues/386
- delete static route
- delete fleet

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
