### PR TITLE
575 - Add /apis/{namespace}/{name} PUT method for updating a single API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -114,6 +114,53 @@ paths:
                 $ref: "#/components/schemas/ApiItem"
         404:
           description: "API item not found"
+    put:
+      tags:
+        - "apis"
+      summary: "Update an existing API"
+      description: "Updates an existing API in the cluster"
+      operationId: updateApi
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+            default: "default"
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: "API content that needs to be updated"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+                envoyFleetName:
+                  type: string
+                envoyFleetNamespace:
+                  type: string
+                openapi:
+                  type: string
+      responses:
+        201:
+          description: "API deployed"
+        400:
+          description: "The content of the API is malformed"
+          content:
+            application/json:
+              schema:
+                type: string
+        404:
+          description: "API not found"
     delete:
       tags:
         - "apis"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     build: ./server
     environment:
       - KUBECONFIG=/kube/config
+      - ANALYTICS_ENABLED=false
     volumes:
       - $HOME/.kube/config:/kube/config:ro
     ports:

--- a/server/go/api.go
+++ b/server/go/api.go
@@ -87,6 +87,7 @@ type StaticRoutesApiRouter interface {
 // and updated with the logic required for the API.
 type ApisApiServicer interface {
 	DeleteApi(context.Context, string, string) (ImplResponse, error)
+	UpdateApi(context.Context, InlineObject) (ImplResponse, error)
 	DeployApi(context.Context, InlineObject) (ImplResponse, error)
 	GetApi(context.Context, string, string) (ImplResponse, error)
 	GetApiCRD(context.Context, string, string) (ImplResponse, error)

--- a/server/go/api_apis_service_impl.go
+++ b/server/go/api_apis_service_impl.go
@@ -178,3 +178,15 @@ func (s *ApisApiService) DeleteApi(ctx context.Context, namespace string, name s
 	}
 	return Response(http.StatusOK, nil), nil
 }
+
+// DeleteApi - Delete an API instance by namespace and name
+func (s *ApisApiService) UpdateApi(ctx context.Context, payload InlineObject) (ImplResponse, error) {
+	analytics.SendAnonymousInfo(ctx, s.kuskClient.K8sClient(), "UpdateApi")
+
+	api, err := s.kuskClient.UpdateApi(payload.Namespace, payload.Name, payload.Openapi, payload.EnvoyFleetName, payload.EnvoyFleetNamespace)
+	if err != nil {
+		return Response(http.StatusInternalServerError, err), errors.New("UpdateApi method failed")
+	}
+
+	return Response(http.StatusCreated, api), nil
+}

--- a/server/kusk/client_test.go
+++ b/server/kusk/client_test.go
@@ -133,6 +133,18 @@ func TestDeleteAPI(t *testing.T) {
 	require.NoError(err)
 }
 
+func TestUpdateAPI(t *testing.T) {
+	require := require.New(t)
+
+	tc := NewClient(getFakeClient())
+
+	_, err := tc.UpdateApi("default", "non-existent", "", "test", "default")
+	require.Error(err)
+
+	_, err = tc.UpdateApi("default", "sample", "", "test", "default")
+	require.NoError(err)
+}
+
 func TestGetSvc(t *testing.T) {
 	setup(t)
 	_, err := testClient.GetSvc("default", "kubernetes")
@@ -162,7 +174,7 @@ func TestCreateStaticRoute(t *testing.T) {
 	name := "default"
 	fleetNamespace := "default"
 	fleetName := "/static-route-2"
-	staticRoute, err := testClient.CreateStaticRoute(namespace, name, fleetNamespace, fleetName)
+	staticRoute, err := testClient.CreateStaticRoute(namespace, name, fleetNamespace, fleetName, "")
 
 	require.NoError(err)
 	require.NotNil(staticRoute)


### PR DESCRIPTION
This PR closes https://github.com/kubeshop/kusk-gateway/issues/575

## Changes

- Add `put` method in open api specification for updating a single API
- Add update method in the kusk kubernetes client to handle the updating of the resource
- Implement the UpdateApi controller method which delegates to the kusk kubernetes client to update an API
- Add route in APIs controller for sending requests to update APIs

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
