### PR TITLE
/GET apis - correct order of parameters so GET can query by fleet name and namespace

### DIFF
--- a/server/go/api_apis.go
+++ b/server/go/api_apis.go
@@ -225,7 +225,7 @@ func (c *ApisApiController) GetApis(w http.ResponseWriter, r *http.Request) {
 	fleetnameParam := query.Get("fleetname")
 	fleetnamespaceParam := query.Get("fleetnamespace")
 	namespaceParam := query.Get("namespace")
-	result, err := c.service.GetApis(r.Context(), fleetnameParam, fleetnamespaceParam, namespaceParam)
+	result, err := c.service.GetApis(r.Context(), namespaceParam, fleetnameParam, fleetnamespaceParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)


### PR DESCRIPTION
This pr closes https://github.com/kubeshop/kusk-gateway/issues/663